### PR TITLE
:ref: proposed alternative pushing forwardable query elaboration logic down to the repository

### DIFF
--- a/service/commons/utils/api/src/main/java/org/eclipse/kapua/service/utils/KapuaForwardableEntityRepository.java
+++ b/service/commons/utils/api/src/main/java/org/eclipse/kapua/service/utils/KapuaForwardableEntityRepository.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.utils;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.KapuaForwardableEntity;
+import org.eclipse.kapua.model.KapuaNamedEntity;
+import org.eclipse.kapua.model.query.KapuaForwardableEntityQuery;
+import org.eclipse.kapua.model.query.KapuaListResult;
+import org.eclipse.kapua.storage.KapuaEntityRepository;
+import org.eclipse.kapua.storage.KapuaNamedEntityRepository;
+import org.eclipse.kapua.storage.KapuaUpdatableEntityRepository;
+import org.eclipse.kapua.storage.TxContext;
+
+/**
+ * This contract builds upon {@link KapuaUpdatableEntityRepository} (and in turn {@link KapuaEntityRepository},
+ * adding functionalities specific to Kapua Entities that are implement the contract {@link KapuaNamedEntity} (as in: have a name and description fields)
+ *
+ * @param <E> The specific subclass of {@link KapuaEntity} handled by this repository
+ * @param <L> The specific subclass of {@link KapuaListResult}&lt;E&gt; meant to hold list results for the kapua entity handled by this repo
+ * @since 2.0.0
+ */
+public interface KapuaForwardableEntityRepository<E extends KapuaForwardableEntity, L extends KapuaListResult<E>>
+        extends KapuaNamedEntityRepository<E, L> {
+    L query(TxContext txContext, KapuaForwardableEntityQuery kapuaQuery) throws KapuaException;
+
+    long count(TxContext txContext, KapuaForwardableEntityQuery kapuaQuery) throws KapuaException;
+
+}

--- a/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaEntityQueryUtilImpl.java
+++ b/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaEntityQueryUtilImpl.java
@@ -12,31 +12,30 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.utils.internal;
 
-import javax.validation.constraints.NotNull;
-
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.KapuaForwardableEntityAttributes;
-import org.eclipse.kapua.model.KapuaNamedEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaForwardableEntityQuery;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.model.query.predicate.OrPredicate;
-import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
 
+import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
+
 /**
- * Base {@code interface} for all {@link KapuaService}s that are managing {@link KapuaNamedEntity}es.
+ * Implementation of converter between {@link KapuaForwardableEntityQuery} and {@link KapuaQuery}
  *
- * @param <E> Type of the {@link KapuaNamedEntity} being managed.
- * @since 1.0.0
+ * @since 2.0.0
  */
 public class KapuaEntityQueryUtilImpl implements KapuaEntityQueryUtil {
 
     private final AccountRelativeFinder accountRelativeFinder;
 
+    @Inject
     public KapuaEntityQueryUtilImpl(AccountRelativeFinder accountRelativeFinder) {
         this.accountRelativeFinder = accountRelativeFinder;
     }
@@ -44,7 +43,7 @@ public class KapuaEntityQueryUtilImpl implements KapuaEntityQueryUtil {
     @Override
     public KapuaQuery transformInheritedQuery(@NotNull KapuaForwardableEntityQuery query) throws KapuaException {
         // Transform only if this option is enabled
-        if(!query.getIncludeInherited()) {
+        if (!query.getIncludeInherited()) {
             return query;
         }
 
@@ -57,7 +56,7 @@ public class KapuaEntityQueryUtilImpl implements KapuaEntityQueryUtil {
         query.setScopeId(KapuaId.ANY);
         OrPredicate forwardableAncestorPreds = query.orPredicate();
 
-        for(KapuaId id : accountRelativeFinder.findParentIds(scopeId)) {
+        for (KapuaId id : accountRelativeFinder.findParentIds(scopeId)) {
             AndPredicate scopedForwardablePred = query.andPredicate(query.attributePredicate(KapuaEntityAttributes.SCOPE_ID, id));
             scopedForwardablePred = scopedForwardablePred.and(query.attributePredicate(KapuaForwardableEntityAttributes.FORWARDABLE, true));
 

--- a/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaForwardableEntityJpaRepository.java
+++ b/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaForwardableEntityJpaRepository.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.utils.internal;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.KapuaJpaRepositoryConfiguration;
+import org.eclipse.kapua.commons.jpa.KapuaNamedEntityJpaRepository;
+import org.eclipse.kapua.model.KapuaForwardableEntity;
+import org.eclipse.kapua.model.query.KapuaForwardableEntityQuery;
+import org.eclipse.kapua.model.query.KapuaListResult;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
+import org.eclipse.kapua.service.utils.KapuaForwardableEntityRepository;
+import org.eclipse.kapua.storage.TxContext;
+
+import java.util.function.Supplier;
+
+public class KapuaForwardableEntityJpaRepository<E extends KapuaForwardableEntity, C extends E, L extends KapuaListResult<E>>
+        extends KapuaNamedEntityJpaRepository<E, C, L>
+        implements KapuaForwardableEntityRepository<E, L> {
+    private final KapuaEntityQueryUtil kapuaEntityQueryUtil;
+
+    public KapuaForwardableEntityJpaRepository(
+            Class<C> concreteClass,
+            String entityName,
+            Supplier<L> listSupplier,
+            KapuaJpaRepositoryConfiguration jpaRepoConfig,
+            KapuaEntityQueryUtil kapuaEntityQueryUtil) {
+        super(concreteClass, entityName, listSupplier, jpaRepoConfig);
+        this.kapuaEntityQueryUtil = kapuaEntityQueryUtil;
+    }
+
+    @Override
+    public L query(TxContext txContext, KapuaForwardableEntityQuery kapuaQuery) throws KapuaException {
+        return doQuery(txContext, kapuaQuery);
+    }
+
+    @Override
+    public L query(TxContext txContext, KapuaQuery listQuery) throws KapuaException {
+        // Transform the query for the includeInherited option
+        return (listQuery instanceof KapuaForwardableEntityQuery)
+                ? this.doQuery(txContext, (KapuaForwardableEntityQuery) listQuery) : super.query(txContext, listQuery);
+    }
+
+    private L doQuery(TxContext txContext, KapuaForwardableEntityQuery kapuaQuery) throws KapuaException {
+        final KapuaQuery query = kapuaEntityQueryUtil.transformInheritedQuery(kapuaQuery);
+        return super.query(txContext, query);
+    }
+
+    @Override
+    public long count(TxContext txContext, KapuaForwardableEntityQuery kapuaQuery) throws KapuaException {
+        return doCount(txContext, kapuaQuery);
+    }
+
+    @Override
+    public long count(TxContext txContext, KapuaQuery countQuery) throws KapuaException {
+        // Transform the query for the includeInherited option
+        return (countQuery instanceof KapuaForwardableEntityQuery)
+                ? this.count(txContext, (KapuaForwardableEntityQuery) countQuery) : super.count(txContext, countQuery);
+    }
+
+    private long doCount(TxContext txContext, KapuaForwardableEntityQuery kapuaQuery) throws KapuaException {
+        final KapuaQuery query = kapuaEntityQueryUtil.transformInheritedQuery(kapuaQuery);
+        return super.count(txContext, query);
+    }
+}

--- a/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaServiceUtilsModule.java
+++ b/service/commons/utils/internal/src/main/java/org/eclipse/kapua/service/utils/internal/KapuaServiceUtilsModule.java
@@ -12,25 +12,16 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.utils.internal;
 
-import javax.inject.Singleton;
-
-import org.eclipse.kapua.commons.configuration.AccountRelativeFinder;
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
 
-import com.google.inject.Provides;
+import javax.inject.Singleton;
 
 public class KapuaServiceUtilsModule extends AbstractKapuaModule {
 
     @Override
     protected void configureModule() {
+        bind(KapuaEntityQueryUtil.class).to(KapuaEntityQueryUtilImpl.class).in(Singleton.class);
         // nothing to do here
     }
-
-    @Provides
-    @Singleton
-    KapuaEntityQueryUtil kapuaEntityQueryUtil(AccountRelativeFinder accountRelativeFinder) {
-        return new KapuaEntityQueryUtilImpl(accountRelativeFinder);
-    }
-
 }

--- a/service/security/certificate/api/pom.xml
+++ b/service/security/certificate/api/pom.xml
@@ -36,6 +36,10 @@
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-commons-utils-api</artifactId>
+        </dependency>
     </dependencies>
 
 

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateRepository.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateRepository.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate;
 
-import org.eclipse.kapua.storage.KapuaNamedEntityRepository;
+import org.eclipse.kapua.service.utils.KapuaForwardableEntityRepository;
 
 public interface CertificateRepository
-        extends KapuaNamedEntityRepository<Certificate, CertificateListResult> {
+        extends KapuaForwardableEntityRepository<Certificate, CertificateListResult> {
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoRepository.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoRepository.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate.info;
 
-import org.eclipse.kapua.storage.KapuaNamedEntityRepository;
+import org.eclipse.kapua.service.utils.KapuaForwardableEntityRepository;
 
 public interface CertificateInfoRepository
-        extends KapuaNamedEntityRepository<CertificateInfo, CertificateInfoListResult> {
+        extends KapuaForwardableEntityRepository<CertificateInfo, CertificateInfoListResult> {
 }

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoModule.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoModule.java
@@ -12,15 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate.info.internal;
 
-import javax.inject.Singleton;
-
+import com.google.inject.Provides;
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.service.certificate.CertificateService;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoFactory;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoService;
-import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
 
-import com.google.inject.Provides;
+import javax.inject.Singleton;
 
 public class CertificateInfoModule extends AbstractKapuaModule {
     @Override
@@ -32,12 +30,10 @@ public class CertificateInfoModule extends AbstractKapuaModule {
     @Provides
     @Singleton
     CertificateInfoService certificateInfoService(
-            CertificateService certificateService,
-            KapuaEntityQueryUtil entityQueryUtil) {
+            CertificateService certificateService) {
 
         return new CertificateInfoServiceImpl(
-                certificateService,
-                entityQueryUtil
+                certificateService
         );
     }
 }

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoServiceImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoServiceImpl.java
@@ -25,7 +25,6 @@ import org.eclipse.kapua.service.certificate.info.CertificateInfoListResult;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoQuery;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoService;
 import org.eclipse.kapua.service.certificate.internal.CertificateQueryImpl;
-import org.eclipse.kapua.service.utils.KapuaEntityQueryUtil;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -35,12 +34,10 @@ import java.util.List;
 public class CertificateInfoServiceImpl implements CertificateInfoService {
 
     private final CertificateService certificateService;
-    private final KapuaEntityQueryUtil entityQueryUtil;
 
     @Inject
-    public CertificateInfoServiceImpl(CertificateService certificateService, KapuaEntityQueryUtil entityQueryUtil) {
+    public CertificateInfoServiceImpl(CertificateService certificateService) {
         this.certificateService = certificateService;
-        this.entityQueryUtil = entityQueryUtil;
     }
 
     @Override
@@ -59,11 +56,8 @@ public class CertificateInfoServiceImpl implements CertificateInfoService {
 
         CertificateQuery certificateQuery = new CertificateQueryImpl(query);
 
-        // Transform the query for the includeInherited option
-        final KapuaQuery finalQuery = entityQueryUtil.transformInheritedQuery(certificateQuery);
-
         CertificateInfoListResult publicCertificates = new CertificateInfoListResultImpl();
-        publicCertificates.addItem(certificateService.query(finalQuery).getFirstItem());
+        publicCertificates.addItem(certificateService.query(certificateQuery).getFirstItem());
 
         return publicCertificates;
     }


### PR DESCRIPTION
I'd argue that the exact logic to handle forwardable queries could be handled down at the repository level - thus allowing query (db query!) optimization where possible - and also to avoid people forgetting to call the query conversion method in some service. 